### PR TITLE
Remove unused select import from transactions route

### DIFF
--- a/cardstock-backend/app/routes/transactions.py
+++ b/cardstock-backend/app/routes/transactions.py
@@ -1,0 +1,30 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from ..db import get_db
+from ..models import Transaction, TransactionType, Card
+from ..schemas import TransactionIn, TransactionOut
+from ..security import get_current_user_id
+
+router = APIRouter(prefix="/v1/transactions", tags=["transactions"])
+
+@router.post("", response_model=TransactionOut)
+def create_transaction(payload: TransactionIn, db: Session = Depends(get_db), uid: int = Depends(get_current_user_id)):
+    # Basic existence check for card
+    card = db.get(Card, payload.card_id)
+    if not card:
+        raise HTTPException(status_code=404, detail="Card not found")
+    tx = Transaction(
+        user_id=uid,
+        card_id=payload.card_id,
+        type=TransactionType(payload.type),
+        quantity=payload.quantity,
+        value_cents=payload.value_cents,
+        value_type=payload.value_type,
+        fee_cents=payload.fee_cents,
+        marketplace=payload.marketplace,
+        notes=payload.notes
+    )
+    db.add(tx)
+    db.commit()
+    db.refresh(tx)
+    return TransactionOut.model_validate(tx.__dict__)


### PR DESCRIPTION
## Summary
- remove the unused `select` import from the transactions route module to keep the import block minimal

## Testing
- ruff check cardstock-backend/app/routes/transactions.py

------
https://chatgpt.com/codex/tasks/task_e_68c9d7f44f8c832684cb1a7ebea5e5aa