### PR TITLE
Add backend portfolio state helper

### DIFF
--- a/cardstock-backend/.env.example
+++ b/cardstock-backend/.env.example
@@ -1,0 +1,8 @@
+DATABASE_URL=postgresql+psycopg2://postgres:postgres@localhost:5432/cardstock
+JWT_SECRET=change-this
+JWT_ALG=HS256
+
+FREE_SCAN_LIMIT=20
+FREE_TRACK_LIMIT=15
+PREMIUM_SCAN_LIMIT=100000
+PREMIUM_TRACK_LIMIT=100000

--- a/cardstock-backend/Dockerfile
+++ b/cardstock-backend/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+RUN apt-get update && apt-get install -y build-essential libpq-dev && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app ./app
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]

--- a/cardstock-backend/README.md
+++ b/cardstock-backend/README.md
@@ -1,0 +1,65 @@
+# CardStock Backend (MVP Starter)
+
+A plug‑and‑play FastAPI backend with Docker Compose (Postgres + API) for:
+- Auth (JWT)
+- Transactions (buy/sell/trade)
+- Portfolio (ROI, marks from latest price snapshot)
+- Scan (stub endpoint to integrate your model)
+- Limits (free vs premium placeholders)
+
+## Quick Start (Docker)
+
+```bash
+cd cardstock-backend
+docker compose up --build
+```
+
+API available at: http://localhost:8000 (see `/docs` for Swagger)
+
+Postgres at: localhost:5432 (cardstock / postgres / postgres)
+
+### Seed sample cards
+Open a psql shell into the db container and run seed.sql:
+
+```bash
+docker compose exec -T db psql -U postgres -d cardstock < seed.sql
+```
+
+### Create a user and authenticate
+In `/docs`:
+1) `POST /v1/auth/signup` → copy the `token`
+2) Click **Authorize** (top right) and paste: `Bearer <token>`
+
+### Add price snapshots (so portfolio can mark positions)
+Use your DB client or psql:
+```sql
+INSERT INTO price_snapshots (card_id, grade, source, price_cents, link)
+VALUES (1,'RAW','ebay',25000,'https://example.com'),
+       (2,'RAW','ebay',12000,'https://example.com'),
+       (3,'RAW','ebay',18000,'https://example.com');
+```
+
+### Add transactions
+`POST /v1/transactions`
+```json
+{
+  "card_id": 1,
+  "type": "BUY",
+  "quantity": 1,
+  "value_cents": 15000,
+  "fee_cents": 500,
+  "marketplace": "local"
+}
+```
+
+### View portfolio
+`GET /v1/portfolio`
+
+## Env (optional without Docker)
+Copy `.env.example` → `.env` and set `DATABASE_URL` etc.
+
+## Notes
+- This is intentionally minimal so you can extend quickly.
+- Plug your recognition model into `POST /v1/scan`.
+- Build ingestion workers to populate `price_snapshots` regularly.
+- Limits endpoint returns simple placeholders; wire to real quotas next.

--- a/cardstock-backend/app/db.py
+++ b/cardstock-backend/app/db.py
@@ -1,0 +1,16 @@
+import os
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+DATABASE_URL = os.environ.get("DATABASE_URL", "sqlite+pysqlite:///./cardstock.db")
+
+engine = create_engine(DATABASE_URL, future=True, pool_pre_ping=True)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine, future=True)
+Base = declarative_base()
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/cardstock-backend/app/main.py
+++ b/cardstock-backend/app/main.py
@@ -1,0 +1,17 @@
+from fastapi import FastAPI
+from .db import Base, engine
+from .routes import auth, limits, transactions, portfolio, scan
+
+Base.metadata.create_all(bind=engine)
+
+app = FastAPI(title="CardStock API (MVP)")
+
+app.include_router(auth.router)
+app.include_router(limits.router)
+app.include_router(transactions.router)
+app.include_router(portfolio.router)
+app.include_router(scan.router)
+
+@app.get("/health")
+def health():
+    return {"ok": True}

--- a/cardstock-backend/app/models.py
+++ b/cardstock-backend/app/models.py
@@ -1,0 +1,85 @@
+from enum import Enum as PyEnum
+
+from sqlalchemy import DateTime, ForeignKey, Integer, String, Text
+from sqlalchemy import Enum as SAEnum
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.sql import func
+
+from .db import Base
+
+
+class PlanTier(str, PyEnum):
+    FREE = "FREE"
+    PREMIUM = "PREMIUM"
+
+
+class User(Base):
+    __tablename__ = "users"
+    id: Mapped[int] = mapped_column(primary_key=True, index=True)
+    email: Mapped[str] = mapped_column(
+        String(255), unique=True, index=True, nullable=False
+    )
+    password_hash: Mapped[str] = mapped_column(String(255), nullable=False)
+    plan_tier: Mapped[str] = mapped_column(
+        SAEnum(PlanTier), default=PlanTier.FREE, nullable=False
+    )
+    created_at: Mapped = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+
+
+class Card(Base):
+    __tablename__ = "cards"
+    id: Mapped[int] = mapped_column(primary_key=True)
+    category: Mapped[str] = mapped_column(String(50))  # e.g., 'Pokemon', 'NBA'
+    set_name: Mapped[str] = mapped_column(String(255))
+    year: Mapped[str] = mapped_column(String(10))
+    title: Mapped[str] = mapped_column(String(255))  # player/character + number/variant
+    number: Mapped[str] = mapped_column(String(50), nullable=True)
+    variant: Mapped[str] = mapped_column(String(120), nullable=True)
+
+
+class TransactionType(str, PyEnum):
+    BUY = "BUY"
+    SELL = "SELL"
+    TRADE_IN = "TRADE_IN"
+    TRADE_OUT = "TRADE_OUT"
+    ADJUSTMENT = "ADJUSTMENT"
+
+
+class Transaction(Base):
+    __tablename__ = "transactions"
+    id: Mapped[int] = mapped_column(primary_key=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
+    card_id: Mapped[int] = mapped_column(ForeignKey("cards.id"), index=True)
+    type: Mapped[str] = mapped_column(SAEnum(TransactionType), nullable=False)
+    quantity: Mapped[int] = mapped_column(Integer, default=1)
+    value_cents: Mapped[int] = mapped_column(
+        Integer, default=0
+    )  # cash or assigned value for trades
+    value_type: Mapped[str] = mapped_column(
+        String(10), default="cash"
+    )  # 'cash' or 'card'
+    fee_cents: Mapped[int] = mapped_column(Integer, default=0)
+    marketplace: Mapped[str] = mapped_column(String(50), nullable=True)
+    notes: Mapped[str] = mapped_column(Text, nullable=True)
+    ts: Mapped = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+    user = relationship("User")
+    card = relationship("Card")
+
+
+class PriceSnapshot(Base):
+    __tablename__ = "price_snapshots"
+    id: Mapped[int] = mapped_column(primary_key=True)
+    card_id: Mapped[int] = mapped_column(ForeignKey("cards.id"), index=True)
+    grade: Mapped[str] = mapped_column(
+        String(20), nullable=True
+    )  # e.g., 'RAW', 'PSA 10'
+    source: Mapped[str] = mapped_column(String(50))
+    price_cents: Mapped[int] = mapped_column(Integer)
+    ts: Mapped = mapped_column(DateTime(timezone=True), server_default=func.now())
+    link: Mapped[str] = mapped_column(String(500), nullable=True)
+    raw_json: Mapped[str] = mapped_column(Text, nullable=True)
+
+    card = relationship("Card")

--- a/cardstock-backend/app/routes/auth.py
+++ b/cardstock-backend/app/routes/auth.py
@@ -1,0 +1,29 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+from sqlalchemy import select
+from ..db import get_db
+from ..models import User, PlanTier
+from ..schemas import SignupIn, AuthOut, LoginIn
+from ..security import create_access_token, hash_password, verify_password
+
+router = APIRouter(prefix="/v1/auth", tags=["auth"])
+
+@router.post("/signup", response_model=AuthOut)
+def signup(payload: SignupIn, db: Session = Depends(get_db)):
+    exists = db.execute(select(User).where(User.email == payload.email)).scalar_one_or_none()
+    if exists:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Email already registered")
+    user = User(email=payload.email, password_hash=hash_password(payload.password), plan_tier=PlanTier.FREE)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    token = create_access_token(str(user.id))
+    return {"token": token, "user_id": user.id}
+
+@router.post("/login", response_model=AuthOut)
+def login(payload: LoginIn, db: Session = Depends(get_db)):
+    user = db.execute(select(User).where(User.email == payload.email)).scalar_one_or_none()
+    if not user or not verify_password(payload.password, user.password_hash):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
+    token = create_access_token(str(user.id))
+    return {"token": token, "user_id": user.id}

--- a/cardstock-backend/app/routes/limits.py
+++ b/cardstock-backend/app/routes/limits.py
@@ -1,0 +1,41 @@
+import os
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+from sqlalchemy import select, func
+from ..db import get_db
+from ..models import Transaction, User
+from ..security import get_current_user_id
+
+router = APIRouter(prefix="/v1/me", tags=["limits"])
+
+FREE_SCAN_LIMIT = int(os.environ.get("FREE_SCAN_LIMIT", "20"))
+FREE_TRACK_LIMIT = int(os.environ.get("FREE_TRACK_LIMIT", "15"))
+PREMIUM_SCAN_LIMIT = int(os.environ.get("PREMIUM_SCAN_LIMIT", "100000"))
+PREMIUM_TRACK_LIMIT = int(os.environ.get("PREMIUM_TRACK_LIMIT", "100000"))
+
+
+@router.get("/limits")
+def get_limits(db: Session = Depends(get_db), uid: int = Depends(get_current_user_id)):
+    user = db.get(User, uid)
+    if user.plan_tier == "PREMIUM":
+        return {
+            "scans_remaining": PREMIUM_SCAN_LIMIT,
+            "track_limit": PREMIUM_TRACK_LIMIT,
+            "tracked_count": 0,
+        }
+    else:
+        # tracked_count approximated: unique card_ids in transactions with net qty > 0
+        # (simple version; precise count comes from positions calc)
+        tracked_count = (
+            db.execute(
+                select(func.count(func.distinct(Transaction.card_id))).where(
+                    Transaction.user_id == uid
+                )
+            ).scalar()
+            or 0
+        )
+        return {
+            "scans_remaining": FREE_SCAN_LIMIT,
+            "track_limit": FREE_TRACK_LIMIT,
+            "tracked_count": int(tracked_count),
+        }

--- a/cardstock-backend/app/routes/portfolio.py
+++ b/cardstock-backend/app/routes/portfolio.py
@@ -1,0 +1,14 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+from ..db import get_db
+from ..security import get_current_user_id
+from ..utils_portfolio import compute_portfolio
+from ..schemas import PortfolioOut, PortfolioHolding
+
+router = APIRouter(prefix="/v1/portfolio", tags=["portfolio"])
+
+@router.get("", response_model=PortfolioOut)
+def get_portfolio(db: Session = Depends(get_db), uid: int = Depends(get_current_user_id)):
+    data = compute_portfolio(db, uid)
+    data['holdings'] = [PortfolioHolding(**h) for h in data['holdings']]
+    return data

--- a/cardstock-backend/app/routes/scan.py
+++ b/cardstock-backend/app/routes/scan.py
@@ -1,0 +1,17 @@
+from fastapi import APIRouter, UploadFile, File, Depends
+from ..security import get_current_user_id
+from ..schemas import ScanOut
+
+router = APIRouter(prefix="/v1", tags=["scan"])
+
+@router.post("/scan", response_model=ScanOut)
+async def scan_card(file: UploadFile = File(...), uid: int = Depends(get_current_user_id)):
+    # MVP stub: return static candidates (you would plug your model here)
+    # In production, save file to S3, run recognition, return top-k matches.
+    return {
+        "candidates": [
+            {"card_id": 1, "title": "Pokemon 1999 Base Set Charizard #4 Holo", "confidence": 0.83, "variants": ["RAW","PSA 10","PSA 9"]},
+            {"card_id": 2, "title": "NBA 2019 Prizm Ja Morant #249 Base", "confidence": 0.72, "variants": ["RAW","PSA 10","PSA 9"]},
+            {"card_id": 3, "title": "Pokemon 1999 Base Set Blastoise #2 Holo", "confidence": 0.64, "variants": ["RAW","PSA 10","PSA 9"]},
+        ]
+    }

--- a/cardstock-backend/app/routes/transactions.py
+++ b/cardstock-backend/app/routes/transactions.py
@@ -1,0 +1,35 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from ..db import get_db
+from ..models import Transaction, TransactionType, Card
+from ..schemas import TransactionIn, TransactionOut
+from ..security import get_current_user_id
+
+router = APIRouter(prefix="/v1/transactions", tags=["transactions"])
+
+
+@router.post("", response_model=TransactionOut)
+def create_transaction(
+    payload: TransactionIn,
+    db: Session = Depends(get_db),
+    uid: int = Depends(get_current_user_id),
+):
+    # Basic existence check for card
+    card = db.get(Card, payload.card_id)
+    if not card:
+        raise HTTPException(status_code=404, detail="Card not found")
+    tx = Transaction(
+        user_id=uid,
+        card_id=payload.card_id,
+        type=TransactionType(payload.type),
+        quantity=payload.quantity,
+        value_cents=payload.value_cents,
+        value_type=payload.value_type,
+        fee_cents=payload.fee_cents,
+        marketplace=payload.marketplace,
+        notes=payload.notes,
+    )
+    db.add(tx)
+    db.commit()
+    db.refresh(tx)
+    return TransactionOut.model_validate(tx.__dict__)

--- a/cardstock-backend/app/schemas.py
+++ b/cardstock-backend/app/schemas.py
@@ -1,0 +1,62 @@
+from pydantic import BaseModel, EmailStr
+from typing import Optional, List, Literal
+from datetime import datetime
+
+
+class SignupIn(BaseModel):
+    email: EmailStr
+    password: str
+
+
+class AuthOut(BaseModel):
+    token: str
+    user_id: int
+
+
+class LoginIn(BaseModel):
+    email: EmailStr
+    password: str
+
+
+class TransactionIn(BaseModel):
+    card_id: int
+    type: Literal["BUY", "SELL", "TRADE_IN", "TRADE_OUT", "ADJUSTMENT"]
+    quantity: int = 1
+    value_cents: int = 0
+    value_type: Literal["cash", "card"] = "cash"
+    fee_cents: int = 0
+    marketplace: Optional[str] = None
+    notes: Optional[str] = None
+
+
+class TransactionOut(BaseModel):
+    id: int
+    card_id: int
+    type: str
+    quantity: int
+    value_cents: int
+    fee_cents: int
+    marketplace: Optional[str]
+    notes: Optional[str]
+    ts: datetime
+
+
+class PortfolioHolding(BaseModel):
+    card_id: int
+    title: str
+    quantity: int
+    cost_basis_cents: int
+    mark_cents: int
+    unrealized_cents: int
+
+
+class PortfolioOut(BaseModel):
+    invested_cents: int
+    value_now_cents: int
+    realized_cents: int
+    unrealized_cents: int
+    holdings: List[PortfolioHolding]
+
+
+class ScanOut(BaseModel):
+    candidates: list

--- a/cardstock-backend/app/security.py
+++ b/cardstock-backend/app/security.py
@@ -1,0 +1,33 @@
+import os
+from datetime import datetime, timedelta
+from jose import jwt, JWTError
+from passlib.context import CryptContext
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+http_bearer = HTTPBearer(auto_error=False)
+
+JWT_SECRET = os.environ.get("JWT_SECRET", "dev-secret-change-me")
+JWT_ALG = os.environ.get("JWT_ALG", "HS256")
+ACCESS_TOKEN_EXPIRE_MINUTES = 60 * 24 * 7  # 7 days
+
+def create_access_token(sub: str):
+    to_encode = {"sub": sub, "exp": datetime.utcnow() + timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)}
+    return jwt.encode(to_encode, JWT_SECRET, algorithm=JWT_ALG)
+
+def hash_password(p: str) -> str:
+    return pwd_context.hash(p)
+
+def verify_password(p: str, h: str) -> bool:
+    return pwd_context.verify(p, h)
+
+def get_current_user_id(credentials: HTTPAuthorizationCredentials = Depends(http_bearer)) -> int:
+    if not credentials:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated")
+    token = credentials.credentials
+    try:
+        payload = jwt.decode(token, JWT_SECRET, algorithms=[JWT_ALG])
+        return int(payload.get("sub"))
+    except JWTError:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")

--- a/cardstock-backend/app/utils_portfolio.py
+++ b/cardstock-backend/app/utils_portfolio.py
@@ -1,0 +1,113 @@
+from dataclasses import dataclass
+from typing import Dict
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from .models import Card, PriceSnapshot, Transaction, TransactionType
+
+
+@dataclass
+class PositionState:
+    qty: int = 0
+    cost: float = 0.0
+    realized: int = 0
+
+    def apply_buy(self, quantity: int, value_cents: int, fee_cents: int) -> None:
+        """Apply a buy, trade-in, or adjustment transaction to the position."""
+
+        self.qty += quantity
+        self.cost += value_cents + fee_cents
+
+    def apply_sell(self, quantity: int, value_cents: int, fee_cents: int) -> None:
+        """Apply a sell or trade-out transaction to the position."""
+
+        if self.qty <= 0:
+            return
+
+        avg_cost_per = self.cost / self.qty if self.qty else 0
+        sell_cost = avg_cost_per * quantity
+        proceeds = value_cents - fee_cents
+        realized = proceeds - sell_cost
+
+        self.qty -= quantity
+        self.cost -= sell_cost
+        self.realized += int(realized)
+
+
+def compute_portfolio(db: Session, user_id: int):
+    # Aggregate positions and cost basis from transactions
+    # Simple average cost basis per card; for MVP we won't track lots
+    txs = (
+        db.execute(
+            select(Transaction)
+            .where(Transaction.user_id == user_id)
+            .order_by(Transaction.ts.asc())
+        )
+        .scalars()
+        .all()
+    )
+
+    positions: Dict[int, PositionState] = {}
+    for t in txs:
+        pos = positions.setdefault(t.card_id, PositionState())
+        if t.type in (
+            TransactionType.BUY,
+            TransactionType.TRADE_IN,
+            TransactionType.ADJUSTMENT,
+        ):
+            # Increase qty and cost (cash or assigned)
+            pos.apply_buy(t.quantity, t.value_cents, t.fee_cents)
+        elif t.type in (TransactionType.SELL, TransactionType.TRADE_OUT):
+            # Realize PnL using average cost
+            pos.apply_sell(t.quantity, t.value_cents, t.fee_cents)
+
+    # Now compute marks from last price snapshot per card
+    results = []
+    invested = 0
+    value_now = 0
+    realized_total = 0
+    for card_id, pos in positions.items():
+        if pos.qty <= 0:
+            realized_total += pos.realized
+            continue
+        last_price = (
+            db.execute(
+                select(PriceSnapshot.price_cents)
+                .where(PriceSnapshot.card_id == card_id)
+                .order_by(PriceSnapshot.ts.desc())
+            )
+            .scalars()
+            .first()
+            or 0
+        )
+        mark = last_price * pos.qty
+        unreal = int(mark - pos.cost)
+        invested += int(pos.cost)
+        value_now += int(mark)
+        realized_total += pos.realized
+        title = (
+            db.execute(
+                select(Card.title).where(Card.id == card_id)
+            ).scalar_one_or_none()
+            or f"Card #{card_id}"
+        )
+        results.append(
+            {
+                "card_id": card_id,
+                "title": title,
+                "quantity": int(pos.qty),
+                "cost_basis_cents": int(pos.cost),
+                "mark_cents": int(mark),
+                "unrealized_cents": unreal,
+            }
+        )
+
+    unrealized_total = int(value_now - invested)
+    return {
+        "invested_cents": int(invested),
+        "value_now_cents": int(value_now),
+        "realized_cents": int(realized_total),
+        "unrealized_cents": int(unrealized_total),
+        "holdings": results,
+    }

--- a/cardstock-backend/docker-compose.yml
+++ b/cardstock-backend/docker-compose.yml
@@ -1,0 +1,31 @@
+version: "3.9"
+services:
+  db:
+    image: postgres:16
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: cardstock
+    ports:
+      - "5432:5432"
+    volumes:
+      - dbdata:/var/lib/postgresql/data
+  api:
+    build: .
+    depends_on:
+      - db
+    environment:
+      DATABASE_URL: postgresql+psycopg2://postgres:postgres@db:5432/cardstock
+      JWT_SECRET: "dev-secret-change-me"
+      JWT_ALG: "HS256"
+      FREE_SCAN_LIMIT: "20"
+      FREE_TRACK_LIMIT: "15"
+      PREMIUM_SCAN_LIMIT: "100000"
+      PREMIUM_TRACK_LIMIT: "100000"
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./app:/app/app
+volumes:
+  dbdata:

--- a/cardstock-backend/requirements.txt
+++ b/cardstock-backend/requirements.txt
@@ -1,0 +1,8 @@
+fastapi==0.114.0
+uvicorn[standard]==0.30.5
+SQLAlchemy==2.0.35
+psycopg2-binary==2.9.9
+pydantic==2.9.2
+passlib[bcrypt]==1.7.4
+python-jose==3.3.0
+python-dotenv==1.0.1

--- a/cardstock-backend/seed.sql
+++ b/cardstock-backend/seed.sql
@@ -1,0 +1,6 @@
+-- Minimal seed data for cards and example price snapshots
+INSERT INTO cards (id, category, set_name, year, title, number, variant) VALUES
+(1, 'Pokemon', 'Base Set', '1999', 'Charizard Holo #4', '4', 'Holo'),
+(2, 'NBA', 'Prizm', '2019', 'Ja Morant #249 Base', '249', 'Base'),
+(3, 'Pokemon', 'Base Set', '1999', 'Blastoise Holo #2', '2', 'Holo')
+ON CONFLICT DO NOTHING;


### PR DESCRIPTION
## Summary
- restore the FastAPI backend skeleton under `cardstock-backend` so portfolio utilities are available again
- add a `PositionState` helper in `app/utils_portfolio.py` and refactor `compute_portfolio` to use it for quantity/cost/realized math
- clean up unused imports in backend models, routes, and schemas to satisfy linting

## Testing
- ruff format cardstock-backend/app/utils_portfolio.py
- ruff format cardstock-backend/app/models.py cardstock-backend/app/routes/limits.py cardstock-backend/app/routes/transactions.py cardstock-backend/app/schemas.py
- ruff check cardstock-backend/app
- python -m compileall cardstock-backend/app


------
https://chatgpt.com/codex/tasks/task_e_68c9d11434048326a0e3d0c2c07a15a7